### PR TITLE
Switch to gauges from clicky

### DIFF
--- a/app/views/shared/_analytics.html.haml
+++ b/app/views/shared/_analytics.html.haml
@@ -1,11 +1,12 @@
 :javascript
-  var clicky_site_id = 66407493;
+  var _gauges = _gauges || [];
   (function() {
-    var s = document.createElement('script');
-    s.type = 'text/javascript';
-    s.async = true;
-    s.src = '//static.getclicky.com/js';
-    ( document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0] ).appendChild( s );
+    var t   = document.createElement('script');
+    t.type  = 'text/javascript';
+    t.async = true;
+    t.id    = 'gauges-tracker';
+    t.setAttribute('data-site-id', '4da508b6f5a1f5514c000001');
+    t.src = '//secure.gaug.es/track.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(t, s);
   })();
-%noscript
-  %img{alt: "Clicky", src: "//in.getclicky.com/66407493ns.gif", width: 1, height: 1}


### PR DESCRIPTION
Removes clicky code for gaug.es account.  Might re-factor this again into an appconfig option later.
